### PR TITLE
Add DoGetPosition and DoSetPosition in SatelliteTracedMobilityModel

### DIFF
--- a/model/satellite-traced-mobility-model.cc
+++ b/model/satellite-traced-mobility-model.cc
@@ -128,6 +128,22 @@ SatTracedMobilityModel::DoSetGeoPosition(const GeoCoordinate& position)
 }
 
 Vector
+SatTracedMobilityModel::DoGetPosition() const
+{
+    NS_LOG_FUNCTION(this);
+
+    return DoGetGeoPosition().ToVector();
+}
+
+void
+SatTracedMobilityModel::DoSetPosition(const Vector& position)
+{
+    NS_LOG_FUNCTION(this << position);
+
+    DoSetGeoPosition(GeoCoordinate(position));
+}
+
+Vector
 SatTracedMobilityModel::DoGetVelocity(void) const
 {
     NS_LOG_FUNCTION(this);

--- a/model/satellite-traced-mobility-model.h
+++ b/model/satellite-traced-mobility-model.h
@@ -103,6 +103,16 @@ class SatTracedMobilityModel : public SatMobilityModel
      */
     virtual void DoSetGeoPosition(const GeoCoordinate& position);
 
+    /**
+     * \return cartesian format position as vector
+     */
+    virtual Vector DoGetPosition(void) const;
+
+    /**
+     * \param position position in Cartesian format to set
+     */
+    virtual void DoSetPosition(const Vector& position);
+
     void UpdateGeoPositionFromFile(void);
 
     uint32_t m_satId;


### PR DESCRIPTION
Hello,

While using the SatelliteTracedMobilityModel, I noticed that it does not implement the DoGetPosition and DoSetPosition methods. As a result, calls to DoGetPosition return the default (0, 0, 0) vector instead of the expected Cartesian geo location, unlike other mobility models such as constant position or sgp4.

This behavior leads to incorrect or unexpected results in other NS-3 network stacks that rely on the node's position for calculations, such as path loss and power measurements. For instance, when integrated with the LTE module, it results in an unexpected computation of RSRP/RSRQ. To address this, I’ve added DoGetPosition and DoSetPosition implementations following the approach used in the constant position and SGP4 models.

Thank you. 