### PR TITLE
Use std::shuffle if C++11 or higher

### DIFF
--- a/examples/sat-multicast-example.cc
+++ b/examples/sat-multicast-example.cc
@@ -25,6 +25,9 @@
 #include "ns3/network-module.h"
 #include "ns3/satellite-module.h"
 #include "ns3/traffic-module.h"
+#if __cplusplus >= 201103L
+#include <random>
+#endif
 
 using namespace ns3;
 
@@ -468,7 +471,13 @@ main(int argc, char* argv[])
             }
 
             // randomize users
+#if __cplusplus >= 201103L
+            std::random_device rd;
+            std::mt19937 g(rd());
+            std::shuffle(ids.begin(), ids.end(), g);
+#else
             std::random_shuffle(ids.begin(), ids.end());
+#endif
 
             // set source GW or UT users
             groupSource = users.Get(sources[i]);

--- a/model/satellite-bbframe-container.cc
+++ b/model/satellite-bbframe-container.cc
@@ -27,6 +27,9 @@
 #include <ns3/log.h>
 
 #include <algorithm>
+#if __cplusplus >= 201103L
+#include <random>
+#endif
 #include <cmath>
 #include <deque>
 #include <utility>
@@ -286,7 +289,13 @@ SatBbFrameContainer::GetNextFrame()
 
         if (nonEmptyQueues.empty() == false)
         {
-            std::random_shuffle(nonEmptyQueues.begin(), nonEmptyQueues.end());
+            #if __cplusplus >= 201103L
+                std::random_device rd;
+                std::mt19937 g(rd());
+                std::shuffle(nonEmptyQueues.begin(), nonEmptyQueues.end(), g);
+            #else
+                std::random_shuffle(nonEmptyQueues.begin(), nonEmptyQueues.end());
+            #endif
 
             nextFrame = (*nonEmptyQueues.begin())->front();
             (*nonEmptyQueues.begin())->pop_front();

--- a/model/satellite-frame-allocator.cc
+++ b/model/satellite-frame-allocator.cc
@@ -27,6 +27,9 @@
 #include <ns3/log.h>
 
 #include <algorithm>
+#if __cplusplus >= 201103L
+#include <random>
+#endif
 #include <limits>
 #include <utility>
 #include <vector>
@@ -1364,7 +1367,13 @@ SatFrameAllocator::SortUts()
     }
 
     // sort UTs using random method.
-    std::random_shuffle(uts.begin(), uts.end());
+    #if __cplusplus >= 201103L
+        std::random_device rd;
+        std::mt19937 g(rd());
+        std::shuffle(uts.begin(), uts.end(), g);
+    #else
+        std::random_shuffle(uts.begin(), uts.end());
+    #endif
 
     return uts;
 }
@@ -1382,7 +1391,13 @@ SatFrameAllocator::SortCarriers()
     }
 
     // sort available carriers using random methods.
-    std::random_shuffle(carriers.begin(), carriers.end());
+    #if __cplusplus >= 201103L
+        std::random_device rd;
+        std::mt19937 g(rd());
+        std::shuffle(carriers.begin(), carriers.end(), g);
+    #else
+        std::random_shuffle(carriers.begin(), carriers.end());
+    #endif
 
     return carriers;
 }
@@ -1403,7 +1418,13 @@ SatFrameAllocator::SortUtRcs(Address ut)
     if (rcIndices.size() > 2)
     {
         // sort RCs in UT using random method.
-        std::random_shuffle(rcIndices.begin() + 1, rcIndices.end());
+        #if __cplusplus >= 201103L
+            std::random_device rd;
+            std::mt19937 g(rd());
+            std::shuffle(rcIndices.begin() + 1, rcIndices.end(), g);
+        #else
+            std::random_shuffle(rcIndices.begin() + 1, rcIndices.end());
+        #endif
     }
 
     return rcIndices;


### PR DESCRIPTION
There is a note on https://en.cppreference.com/cpp/algorithm/random_shuffle
> The reason for removing std::random_shuffle in C++17 is that the iterator-only version usually depends on std::rand, which is now also discussed for deprecation. (std::rand should be replaced with the classes of the [<random>](https://en.cppreference.com/cpp/header/random) header, as std::rand is considered harmful.) In addition, the iterator-only std::random_shuffle version usually depends on a global state. The std::shuffle's shuffle algorithm is the preferred replacement, as it uses a URBG as its 3rd parameter.

So, this PR makes the codes use `std::shuffle` instead of `std::random_shuffle` if the compiler is C++11 or higher. It eliminates a deprecation warning, or even resolves a compilation error with the removed `std::random_shuffle`